### PR TITLE
Fix comment typo in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,5 +22,5 @@ html/manifest.json
 html/ms-icon-*
 html/favicons.zip
 
-# Ingore logs
+# Ignore logs
 *.log


### PR DESCRIPTION
## Summary
- correct a typo in `.gitignore`

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_686583676580832b9701f2ed68b8a165